### PR TITLE
Support for username/password authentication

### DIFF
--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -11,11 +11,11 @@ use std::net::{SocketAddrV4, SocketAddr, Ipv4Addr};
 
 fn main() {
     let mut core = tokio_core::reactor::Core::new().unwrap();
-    
+
     // Proxy running on 127.0.0.1:9150 with credentials socksuser/sockspass
     let proxy_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9150));
     let client = Client::configure()
-        .connector(Socksv5Connector::new_with_creds(&core.handle(), proxy_addr, "socksuser", "sockspass").unwrap())
+        .connector(Socksv5Connector::new_with_creds(&core.handle(), proxy_addr, ("socksuser", "sockspass")).unwrap())
         .build(&core.handle());
 
     // http://example.com or http://1.2.3.4 work as well

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,0 +1,27 @@
+extern crate futures;
+extern crate hyper;
+extern crate hyper_socks_async;
+extern crate tokio_core;
+
+use futures::Future;
+use futures::stream::Stream;
+use hyper::Client;
+use hyper_socks_async::Socksv5Connector;
+use std::net::{SocketAddrV4, SocketAddr, Ipv4Addr};
+
+fn main() {
+    let mut core = tokio_core::reactor::Core::new().unwrap();
+    
+    // Proxy running on 127.0.0.1:9150 with credentials socksuser/sockspass
+    let proxy_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9150));
+    let client = Client::configure()
+        .connector(Socksv5Connector::new_with_auth(&core.handle(), proxy_addr, "socksuser", "sockspass").unwrap())
+        .build(&core.handle());
+
+    // http://example.com or http://1.2.3.4 work as well
+    let url = "https://ifconfig.co/json".parse::<hyper::Uri>().unwrap();
+    let response_body = client.get(url)
+        .and_then(|res| res.body().concat2());
+    let bytes = core.run(response_body).expect("Request failed").to_vec();
+    println!("Got: {}", String::from_utf8_lossy(&bytes));
+}

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -15,7 +15,7 @@ fn main() {
     // Proxy running on 127.0.0.1:9150 with credentials socksuser/sockspass
     let proxy_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 9150));
     let client = Client::configure()
-        .connector(Socksv5Connector::new_with_auth(&core.handle(), proxy_addr, "socksuser", "sockspass").unwrap())
+        .connector(Socksv5Connector::new_with_creds(&core.handle(), proxy_addr, "socksuser", "sockspass").unwrap())
         .build(&core.handle());
 
     // http://example.com or http://1.2.3.4 work as well

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,17 +35,25 @@ impl Socksv5Connector {
         }
     }
 
-    pub fn new_with_creds(handle: &Handle, proxy_addr: SocketAddr, username: &str, password: &str) -> io::Result<Socksv5Connector> {
+    pub fn with_creds(mut self, creds: &(&str, &str)) -> io::Result<Socksv5Connector> {
+        let &(ref username, ref password) = creds;
         let u = username.as_bytes();
         let p = password.as_bytes();
         if u.len() > 255 || p.len() > 255 {
             Err(Error::new(ErrorKind::Other, "invalid credentials"))
         } else {
-            Ok(Socksv5Connector {
-                handle: handle.clone(),
-                proxy_addr,
-                creds: Some((u.to_vec(), p.to_vec()))
-            })
+            self.creds = Some((u.to_vec(), p.to_vec()));
+            Ok(self)
+        }
+    }
+
+    pub fn with_creds_binary(mut self, creds: &(Vec<u8>, Vec<u8>)) -> io::Result<Socksv5Connector> {
+        let &(ref username, ref password) = creds;
+        if username.len() > 255 || password.len() > 255 {
+            Err(Error::new(ErrorKind::Other, "invalid credentials"))
+        } else {
+            self.creds = Some((username.to_vec(), password.to_vec()));
+            Ok(self)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ fn auth_negotiation(socket: TcpStream, creds: Option<(Vec<u8>, Vec<u8>)>) -> Han
 }
 
 fn answer_hello(socket: TcpStream, response: [u8;2], creds: Option<(Vec<u8>, Vec<u8>)>) -> HandshakeFuture<TcpStream> {
-    if response[0] == 5 && response[1] == 0 && creds.is_none() {
+    if response[0] == 5 && response[1] == 0 {
         Box::new(write_all(socket, [5, 1, 0]).map( |(socket, _)| socket))
     } else if response[0] == 5 && response[1] == 2 && creds.is_some() {
         Box::new(auth_negotiation(socket, creds)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,25 +35,17 @@ impl Socksv5Connector {
         }
     }
 
-    pub fn with_creds(mut self, creds: &(&str, &str)) -> io::Result<Socksv5Connector> {
-        let &(ref username, ref password) = creds;
-        let u = username.as_bytes();
-        let p = password.as_bytes();
-        if u.len() > 255 || p.len() > 255 {
-            Err(Error::new(ErrorKind::Other, "invalid credentials"))
-        } else {
-            self.creds = Some((u.to_vec(), p.to_vec()));
-            Ok(self)
-        }
-    }
-
-    pub fn with_creds_binary(mut self, creds: &(Vec<u8>, Vec<u8>)) -> io::Result<Socksv5Connector> {
-        let &(ref username, ref password) = creds;
+    pub fn new_with_creds<T: Into<Vec<u8>>>(handle: &Handle, proxy_addr: SocketAddr, creds: (T, T)) -> io::Result<Socksv5Connector> {
+        let username = creds.0.into();
+        let password = creds.1.into();
         if username.len() > 255 || password.len() > 255 {
             Err(Error::new(ErrorKind::Other, "invalid credentials"))
         } else {
-            self.creds = Some((username.to_vec(), password.to_vec()));
-            Ok(self)
+            Ok(Socksv5Connector {
+                handle: handle.clone(),
+                proxy_addr,
+                creds: Some((username, password))
+            })
         }
     }
 }


### PR DESCRIPTION
Thanks for building out the SOCKS spec and integrating it with the latest Hyper!

This PR includes support for using the username authentication method (https://tools.ietf.org/html/rfc1929).

I am new to Rust, so in addition to code improvements I am happy to change anything to match best practices or your own preference.